### PR TITLE
Set the C++ standard the code uses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ project(Discregrid)
 # Visual studio solution directories.
 set_property(GLOBAL PROPERTY USE_FOLDERS on)
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Enable simultaneous compilation of source files.
 if(WIN32)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")


### PR DESCRIPTION
On my machine with GCC 5.4.0, the code did not compile, as C++98 is chosen as the default standard. These changes set the standard to C++14, which is needed for this project.