### PR TITLE
Added a cmake option that allows users to select the configuration of the Discregrid library. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ if(WIN32)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4250")
 endif(WIN32)
 
+OPTION(BUILD_AS_SHARED_LIBS "Build all the libraries as shared" OFF)
+if (BUILD_AS_SHARED_LIBS)
+	add_definitions( -DBUILD_AS_SHARED_LIBS)
+endif (BUILD_AS_SHARED_LIBS)
+
 set(CMAKE_DEBUG_POSTFIX "_d")
 
 # Put all executables and libraries into a common directory.

--- a/discregrid/CMakeLists.txt
+++ b/discregrid/CMakeLists.txt
@@ -100,7 +100,7 @@ if(WIN32)
 	add_definitions(-D_USE_MATH_DEFINES)
 endif(WIN32)
 
-add_library(Discregrid STATIC
+set(DISCREGRID_SOURCE_FILES
 	${HEADERS}
 	${SOURCES}
 	${HEADERS_ACCELERATION}
@@ -113,6 +113,12 @@ add_library(Discregrid STATIC
 	${HEADERS_UTILITY}
 	${SOURCES_UTILITY}
 )
+
+if(BUILD_AS_SHARED_LIBS)
+	add_library(Discregrid SHARED ${DISCREGRID_SOURCE_FILES})
+else()
+	add_library(Discregrid ${DISCREGRID_SOURCE_FILES})
+endif()
 
 # Discregrid has the following dependencies.
 #add_dependencies(Discregrid


### PR DESCRIPTION
This can be either a static or a shared
library. The same boolean exists for all the Interactive Computer Graphics
related projects.