### PR TITLE
macOS compatibility

### DIFF
--- a/cmd/discrete_field_to_bitmap/CMakeLists.txt
+++ b/cmd/discrete_field_to_bitmap/CMakeLists.txt
@@ -19,16 +19,15 @@ if ( CMAKE_COMPILER_IS_GNUCC )
 endif ( CMAKE_COMPILER_IS_GNUCC )
 
 # OpenMP support.
-if(APPLE)
-	include(PatchOpenMPApple)
-else()
-	find_package(OpenMP REQUIRED)
-endif()
-
+find_package(OpenMP REQUIRED)
 if(OPENMP_FOUND)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+	if (CMAKE_VERSION VERSION_GREATER "3.8")
+		link_libraries(OpenMP::OpenMP_CXX)
+	else()
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+	endif()
 endif()
 
 add_executable(DiscreteFieldToBitmap

--- a/cmd/generate_density_map/CMakeLists.txt
+++ b/cmd/generate_density_map/CMakeLists.txt
@@ -13,25 +13,24 @@ if(WIN32)
 	add_definitions(-D_USE_MATH_DEFINES)
 endif(WIN32)
 
+# OpenMP support.
+find_package(OpenMP REQUIRED)
+if(OPENMP_FOUND)
+	if (CMAKE_VERSION VERSION_GREATER "3.8")
+		link_libraries(OpenMP::OpenMP_CXX)
+	else()
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+	endif()
+endif()
+
 add_executable(GenerateDensityMap
 	main.cpp
 	gauss_quadrature.hpp
 	gauss_quadrature.cpp
 	sph_kernel.hpp
 )
-
-# OpenMP support.
-if(APPLE)
-	include(PatchOpenMPApple)
-else()
-	find_package(OpenMP REQUIRED)
-endif()
-
-if(OPENMP_FOUND)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-endif()
 
 add_dependencies(GenerateDensityMap
 	Discregrid

--- a/cmd/generate_sdf/CMakeLists.txt
+++ b/cmd/generate_sdf/CMakeLists.txt
@@ -18,16 +18,15 @@ if(WIN32)
 endif(WIN32)
 
 # OpenMP support.
-if(APPLE)
-	include(PatchOpenMPApple)
-else()
-	find_package(OpenMP REQUIRED)
-endif()
-
+find_package(OpenMP REQUIRED)
 if(OPENMP_FOUND)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+	if (CMAKE_VERSION VERSION_GREATER "3.8")
+		link_libraries(OpenMP::OpenMP_CXX)
+	else()
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+	endif()
 endif()
 
 add_executable(GenerateSDF

--- a/discregrid/CMakeLists.txt
+++ b/discregrid/CMakeLists.txt
@@ -52,16 +52,15 @@ SOURCEGROUP(UTILITY)
 SOURCEGROUP(GEOMETRY)
 
 # OpenMP support.
-if(APPLE)
-	include(PatchOpenMPApple)
-else()
-	find_package(OpenMP REQUIRED)
-endif()
-
+find_package(OpenMP REQUIRED)
 if(OPENMP_FOUND)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+	if (CMAKE_VERSION VERSION_GREATER "3.8")
+		link_libraries(OpenMP::OpenMP_CXX)
+	else()
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+	endif()
 endif()
 
 # Eigen library.


### PR DESCRIPTION
These adaptations allow builds using Clang on recent versions of macOS (tested on Apple silicon):

- Recent versions of CMake automatically determine the correct flags for OpenMP and provide a target to link against. Nevertheless, Clang does not include an OpenMP implementation on macOS by default, but the user can easily install a build of LLVM libomp (e.g. via Homebrew) to be shared by all projects requiring OpenMP which is then detected by CMake.