### PR TITLE
Remove deprecated std::iterator

### DIFF
--- a/discregrid/include/Discregrid/mesh/entity_iterators.hpp
+++ b/discregrid/include/Discregrid/mesh/entity_iterators.hpp
@@ -12,10 +12,14 @@ namespace Discregrid
 class TriangleMesh;
 
 class FaceContainer;
-class FaceIterator : public
-	std::iterator<std::random_access_iterator_tag, std::array<unsigned int, 3>>
+class FaceIterator
 {
 public:
+	using iterator_category = std::random_access_iterator_tag;
+    using value_type = std::array<unsigned int, 3>;
+    using difference_type = unsigned int;
+    using pointer = std::array<unsigned int, 3>*;
+    using reference = std::array<unsigned int, 3>&;
 
 	typedef FaceIterator _Mytype;
 
@@ -65,11 +69,15 @@ private:
 	unsigned int m_index;
 	TriangleMesh* m_mesh;
 };
-class FaceConstIterator : public
-	std::iterator<std::random_access_iterator_tag, std::array<unsigned int, 3> const>
+class FaceConstIterator
 {
 
 public:
+	using iterator_category = std::random_access_iterator_tag;
+    using value_type = std::array<unsigned int, 3> const;
+    using difference_type = unsigned int const;
+    using pointer = std::array<unsigned int, 3> const*;
+    using reference = std::array<unsigned int, 3> const&;
 
 	typedef FaceConstIterator _Mytype;
 
@@ -121,10 +129,15 @@ private:
 };
 
 class IncidentFaceContainer;
-class IncidentFaceIterator : public std::iterator<std::forward_iterator_tag, Halfedge>
+class IncidentFaceIterator
 {
 
 public:
+	using iterator_category = std::forward_iterator_tag;
+    using value_type = Halfedge;
+    using difference_type = Halfedge;
+    using pointer = Halfedge*;
+    using reference = Halfedge&;
 
 	typedef IncidentFaceIterator _Mytype;
 
@@ -152,10 +165,15 @@ private:
 
 
 class VertexContainer;
-class VertexIterator : public std::iterator<std::random_access_iterator_tag, Eigen::Vector3d>
+class VertexIterator
 {
 
 public:
+	using iterator_category = std::random_access_iterator_tag;
+    using value_type = Eigen::Vector3d;
+    using difference_type = double;
+    using pointer = Eigen::Vector3d*;
+    using reference = Eigen::Vector3d&;
 
 	typedef VertexIterator _Mytype;
 
@@ -207,11 +225,15 @@ private:
 
 
 class VertexConstContainer;
-class VertexConstIterator : 
-	public std::iterator<std::random_access_iterator_tag, Eigen::Vector3d const>
+class VertexConstIterator
 {
 
 public:
+	using iterator_category = std::random_access_iterator_tag;
+    using value_type = Eigen::Vector3d const;
+    using difference_type = double const;
+    using pointer = Eigen::Vector3d* const;
+    using reference = Eigen::Vector3d const&;
 
 	typedef VertexConstIterator _Mytype;
 
@@ -261,4 +283,3 @@ private:
 	TriangleMesh const* m_mesh;
 };
 }
-

--- a/discregrid/include/Discregrid/mesh/entity_iterators.hpp
+++ b/discregrid/include/Discregrid/mesh/entity_iterators.hpp
@@ -17,9 +17,9 @@ class FaceIterator
 public:
     using iterator_category = std::random_access_iterator_tag;
     using value_type = std::array<unsigned int, 3>;
-    using difference_type = unsigned int;
-    using pointer = std::array<unsigned int, 3>*;
-    using reference = std::array<unsigned int, 3>&;
+    using difference_type = ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
 
 	typedef FaceIterator _Mytype;
 
@@ -75,9 +75,9 @@ class FaceConstIterator
 public:
     using iterator_category = std::random_access_iterator_tag;
     using value_type = std::array<unsigned int, 3> const;
-    using difference_type = unsigned int const;
-    using pointer = std::array<unsigned int, 3> const*;
-    using reference = std::array<unsigned int, 3> const&;
+    using difference_type = ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
 
 	typedef FaceConstIterator _Mytype;
 
@@ -135,9 +135,9 @@ class IncidentFaceIterator
 public:
     using iterator_category = std::forward_iterator_tag;
     using value_type = Halfedge;
-    using difference_type = unsigned int;
-    using pointer = Halfedge*;
-    using reference = Halfedge&;
+    using difference_type = ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
 
 	typedef IncidentFaceIterator _Mytype;
 
@@ -171,9 +171,9 @@ class VertexIterator
 public:
     using iterator_category = std::random_access_iterator_tag;
     using value_type = Eigen::Vector3d;
-    using difference_type = unsigned int;
-    using pointer = Eigen::Vector3d*;
-    using reference = Eigen::Vector3d&;
+    using difference_type = ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
 
 	typedef VertexIterator _Mytype;
 
@@ -231,9 +231,9 @@ class VertexConstIterator
 public:
     using iterator_category = std::random_access_iterator_tag;
     using value_type = Eigen::Vector3d const;
-    using difference_type = unsigned int const;
-    using pointer = Eigen::Vector3d* const;
-    using reference = Eigen::Vector3d const&;
+    using difference_type = ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
 
 	typedef VertexConstIterator _Mytype;
 

--- a/discregrid/include/Discregrid/mesh/entity_iterators.hpp
+++ b/discregrid/include/Discregrid/mesh/entity_iterators.hpp
@@ -15,7 +15,7 @@ class FaceContainer;
 class FaceIterator
 {
 public:
-	using iterator_category = std::random_access_iterator_tag;
+    using iterator_category = std::random_access_iterator_tag;
     using value_type = std::array<unsigned int, 3>;
     using difference_type = unsigned int;
     using pointer = std::array<unsigned int, 3>*;
@@ -73,7 +73,7 @@ class FaceConstIterator
 {
 
 public:
-	using iterator_category = std::random_access_iterator_tag;
+    using iterator_category = std::random_access_iterator_tag;
     using value_type = std::array<unsigned int, 3> const;
     using difference_type = unsigned int const;
     using pointer = std::array<unsigned int, 3> const*;
@@ -133,7 +133,7 @@ class IncidentFaceIterator
 {
 
 public:
-	using iterator_category = std::forward_iterator_tag;
+    using iterator_category = std::forward_iterator_tag;
     using value_type = Halfedge;
     using difference_type = Halfedge;
     using pointer = Halfedge*;
@@ -169,7 +169,7 @@ class VertexIterator
 {
 
 public:
-	using iterator_category = std::random_access_iterator_tag;
+    using iterator_category = std::random_access_iterator_tag;
     using value_type = Eigen::Vector3d;
     using difference_type = double;
     using pointer = Eigen::Vector3d*;
@@ -229,7 +229,7 @@ class VertexConstIterator
 {
 
 public:
-	using iterator_category = std::random_access_iterator_tag;
+    using iterator_category = std::random_access_iterator_tag;
     using value_type = Eigen::Vector3d const;
     using difference_type = double const;
     using pointer = Eigen::Vector3d* const;
@@ -283,3 +283,4 @@ private:
 	TriangleMesh const* m_mesh;
 };
 }
+

--- a/discregrid/include/Discregrid/mesh/entity_iterators.hpp
+++ b/discregrid/include/Discregrid/mesh/entity_iterators.hpp
@@ -106,7 +106,7 @@ public:
 	{
 		return _Mytype(m_index + rhs.m_index, m_mesh);
 	}
-	inline ype operator-(_Mytype const& rhs) const
+	inline difference_type operator-(_Mytype const& rhs) const
 	{
 		return m_index - rhs.m_index;
 	}

--- a/discregrid/include/Discregrid/mesh/entity_iterators.hpp
+++ b/discregrid/include/Discregrid/mesh/entity_iterators.hpp
@@ -106,7 +106,7 @@ public:
 	{
 		return _Mytype(m_index + rhs.m_index, m_mesh);
 	}
-	inline difference_type operator-(_Mytype const& rhs) const
+	inline ype operator-(_Mytype const& rhs) const
 	{
 		return m_index - rhs.m_index;
 	}
@@ -135,7 +135,7 @@ class IncidentFaceIterator
 public:
     using iterator_category = std::forward_iterator_tag;
     using value_type = Halfedge;
-    using difference_type = Halfedge;
+    using difference_type = unsigned int;
     using pointer = Halfedge*;
     using reference = Halfedge&;
 
@@ -171,7 +171,7 @@ class VertexIterator
 public:
     using iterator_category = std::random_access_iterator_tag;
     using value_type = Eigen::Vector3d;
-    using difference_type = double;
+    using difference_type = unsigned int;
     using pointer = Eigen::Vector3d*;
     using reference = Eigen::Vector3d&;
 
@@ -231,7 +231,7 @@ class VertexConstIterator
 public:
     using iterator_category = std::random_access_iterator_tag;
     using value_type = Eigen::Vector3d const;
-    using difference_type = double const;
+    using difference_type = unsigned int const;
     using pointer = Eigen::Vector3d* const;
     using reference = Eigen::Vector3d const&;
 


### PR DESCRIPTION
std::iterator is deprecated and it does not allow building with -Wdeprecated-declarations. This PR substitutes them with an explicit declaration of all of the types required.